### PR TITLE
Have FilePath functions return a String when appropriate

### DIFF
--- a/src/UVMHS/Core/FilePath.hs
+++ b/src/UVMHS/Core/FilePath.hs
@@ -20,14 +20,14 @@ pnull = ℙ ""
 pappend ∷ ℙ → ℙ → ℙ
 pappend x y = ℙ $ string $ tohsChars (unℙ x) FP.</> tohsChars (unℙ y)
 
-pfilename ∷ ℙ → ℙ
-pfilename = ℙ ∘ string ∘ FP.takeFileName ∘ tohsChars ∘ unℙ
+pfilename ∷ ℙ → 𝕊
+pfilename = string ∘ FP.takeFileName ∘ tohsChars ∘ unℙ
 
-pbasename ∷ ℙ → ℙ
-pbasename = ℙ ∘ string ∘ FP.takeBaseName ∘ tohsChars ∘ unℙ
+pbasename ∷ ℙ → 𝕊
+pbasename = string ∘ FP.takeBaseName ∘ tohsChars ∘ unℙ
 
 pdirectory ∷ ℙ → ℙ
 pdirectory = ℙ ∘ string ∘ FP.takeDirectory ∘ tohsChars ∘ unℙ
 
-pextension ∷ ℙ → ℙ
-pextension = ℙ ∘ string ∘ FP.takeExtension ∘ tohsChars ∘ unℙ
+pextension ∷ ℙ → 𝕊
+pextension = string ∘ FP.takeExtension ∘ tohsChars ∘ unℙ


### PR DESCRIPTION
Changed the return types of bfilename, pbasename and pextension from ℙ to 𝕊 to match the signatures in System.FilePath

