### PR TITLE
fix curry/uncurry being swapped

### DIFF
--- a/src/UVMHS/Core/Init.hs
+++ b/src/UVMHS/Core/Init.hs
@@ -390,11 +390,11 @@ mirror f = \ c b a → f a b c
 on ∷ (b → b → c) → (a → b) → (a → a → c)
 on p f = \ x y → p (f x) (f y)
 
-curry ∷ (a → b → c) → a ∧ b → c
-curry f (x :* y) = f x y
+uncurry ∷ (a → b → c) → a ∧ b → c
+uncurry f (x :* y) = f x y
 
-uncurry ∷ (a ∧ b → c) → a → b → c
-uncurry f x y = f (x :* y)
+curry ∷ (a ∧ b → c) → a → b → c
+curry f x y = f (x :* y)
 
 
 -----------------------------------


### PR DESCRIPTION
Currying is the process of turning a function that takes its arguments all at once into a function that takes them one by one.  In UVMHS, they are currently defined "backwards" wrt. the common use definition.