### PR TITLE
Update to GHC 9.10.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /.stack-work
 /dist/
 /dist-newstyle/
-/uvmhs.cabal

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@ verbatim:
   cabal-version: 2.2
 
 name: uvmhs
-version: 0.0.1.0
+version: 0.0.2.0
 
 default-extensions:
   - ConstraintKinds

--- a/src/UVMHS/Lib/Testing.hs
+++ b/src/UVMHS/Lib/Testing.hs
@@ -148,15 +148,17 @@ runTests noisy γ tests = do
 𝔱 tag xEQ yEQ = 𝔱T @() tag (TH.unsafeCodeCoerce xEQ) (TH.unsafeCodeCoerce yEQ)
 #endif
 
+newtype TypedTest = TypedTest { unTypedTest ∷ TH.CodeQ (𝑇D Test) }
+
 𝔱T ∷ (Eq a,Pretty a) ⇒ 𝕊 → TH.CodeQ a → TH.CodeQ a → TH.Q [TH.Dec]
 𝔱T tag xE yE = do
   l ← TH.location
   let lS = concat [frhsChars $ TH.loc_module l,":",show𝕊 $ fst $ frhs $ TH.loc_start l]
   let tags = list $ splitOn𝕊 ":" tag
-  tests ← ifNone null ∘ frhs𝑂 ^$ TH.getQ @(𝐼 (TH.CodeQ (𝑇D Test)))
+  tests ← ifNone null ∘ frhs𝑂 ^$ TH.getQ @(𝐼 TypedTest)
   let t = [|| eqTest tags lS $$xE $$yE ||]
-      tests' = tests ⧺ single t
-  TH.putQ @(𝐼 (TH.CodeQ (𝑇D Test))) tests'
+      tests' = tests ⧺ single (TypedTest t)
+  TH.putQ @(𝐼 TypedTest) tests'
   return []
 
 𝔣 ∷ 𝕊 → TH.ExpQ → TH.ExpQ → TH.ExpQ → TH.Q [TH.Dec]
@@ -175,21 +177,21 @@ runTests noisy γ tests = do
         , show𝕊 $ fst $ frhs $ TH.loc_start l
         ]
   let tags = list $ splitOn𝕊 ":" tag
-  tests ← ifNone null ∘ frhs𝑂 ^$ TH.getQ @(𝐼 (TH.CodeQ (𝑇D Test)))
+  tests ← ifNone null ∘ frhs𝑂 ^$ TH.getQ @(𝐼 TypedTest)
   let t' = [|| fuzzTest tags lS $$xIOE $$pE $$xDE ||]
-      tests' = tests ⧺ single t'
-  TH.putQ @(𝐼 (TH.CodeQ (𝑇D Test))) tests'
+      tests' = tests ⧺ single (TypedTest t')
+  TH.putQ @(𝐼 TypedTest) tests'
   return []
 
 buildTests ∷ TH.Q [TH.Dec]
 buildTests = do
-  testEQs ← ifNone null ∘ frhs𝑂 ^$ TH.getQ @(𝐼 (TH.CodeQ (𝑇D Test)))
+  testEQs ← ifNone null ∘ frhs𝑂 ^$ TH.getQ @(𝐼 TypedTest)
   l ← TH.location
   let modNameS = frhsChars $ TH.loc_module l
       testsNameS = "g__TESTS__" ⧺ replace𝕊 "." "__" modNameS
       testsName = TH.mkName $ tohsChars testsNameS
       testEQs' ∷ TH.CodeQ [𝑇D Test]
-      testEQs' = TH.Code $ TH.TExp ^$ TH.listE $ lazyList $ map TH.unTypeCode testEQs
+      testEQs' = TH.Code $ TH.TExp ^$ TH.listE $ lazyList $ map (TH.unTypeCode ∘ unTypedTest) testEQs
       testsEQ ∷ TH.CodeQ (𝑇D Test)
       testsEQ = [|| concat $$testEQs' ||]
   concat ^$ exchange $

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
 packages: ["."]
-resolver: lts-23.24
+resolver: lts-24.43

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 400dfb2174640dd2f9f2ba7cbf9148699f2380ab64faa46f4be298a5d6205316
-    size: 684057
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/24.yaml
-  original: lts-23.24
+    sha256: 3c412a7c13dba6d3d808455a458e0776c58b6cf99b8a7961a2f5e55589d6f1d6
+    size: 729011
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/24/43.yaml
+  original: lts-24.43

--- a/uvmhs.cabal
+++ b/uvmhs.cabal
@@ -1,0 +1,339 @@
+cabal-version: 2.2
+
+-- This file has been generated from package.yaml by hpack version 0.38.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           uvmhs
+version:        0.0.1.0
+build-type:     Simple
+
+flag no-uvmhs-tests
+  description: Disables building tests, which increases compile times
+  manual: True
+  default: False
+
+library
+  exposed-modules:
+      Examples.Lang.Arith
+      Examples.Lang.ArithBlocks
+      Examples.Lang.SExp
+      UVMHS
+      UVMHS.Core
+      UVMHS.Core.Chunky
+      UVMHS.Core.Classes
+      UVMHS.Core.Classes.Arithmetic
+      UVMHS.Core.Classes.Bitty
+      UVMHS.Core.Classes.Collections
+      UVMHS.Core.Classes.Comonad
+      UVMHS.Core.Classes.Constraints
+      UVMHS.Core.Classes.DSL
+      UVMHS.Core.Classes.Functors
+      UVMHS.Core.Classes.Lattice
+      UVMHS.Core.Classes.Monoid
+      UVMHS.Core.Classes.Morphism
+      UVMHS.Core.Classes.Order
+      UVMHS.Core.Data
+      UVMHS.Core.Data.Arithmetic
+      UVMHS.Core.Data.Bitty
+      UVMHS.Core.Data.Bool
+      UVMHS.Core.Data.Char
+      UVMHS.Core.Data.Choice
+      UVMHS.Core.Data.Dict
+      UVMHS.Core.Data.Function
+      UVMHS.Core.Data.Iter
+      UVMHS.Core.Data.Lattice
+      UVMHS.Core.Data.LazyList
+      UVMHS.Core.Data.Lens
+      UVMHS.Core.Data.List
+      UVMHS.Core.Data.Option
+      UVMHS.Core.Data.Pair
+      UVMHS.Core.Data.Sequence
+      UVMHS.Core.Data.Set
+      UVMHS.Core.Data.Stream
+      UVMHS.Core.Data.String
+      UVMHS.Core.Data.Unit
+      UVMHS.Core.Effects
+      UVMHS.Core.FilePath
+      UVMHS.Core.Init
+      UVMHS.Core.IO
+      UVMHS.Core.LensDerivedInstances
+      UVMHS.Core.LensDeriving
+      UVMHS.Core.Monads
+      UVMHS.Core.Pointed
+      UVMHS.Core.Sized
+      UVMHS.Core.Static
+      UVMHS.Core.TH
+      UVMHS.Core.Time
+      UVMHS.Core.Transformers
+      UVMHS.Core.Vector
+      UVMHS.Core.VectorSparse
+      UVMHS.Core.VectorStatic
+      UVMHS.Lang.ULC
+      UVMHS.Lib.AD
+      UVMHS.Lib.Annotated
+      UVMHS.Lib.Dataframe
+      UVMHS.Lib.Errors
+      UVMHS.Lib.Fuzzy
+      UVMHS.Lib.Graph
+      UVMHS.Lib.GTree
+      UVMHS.Lib.Logging
+      UVMHS.Lib.MMSP
+      UVMHS.Lib.Neural
+      UVMHS.Lib.Options
+      UVMHS.Lib.Parser
+      UVMHS.Lib.Parser.Core
+      UVMHS.Lib.Parser.CParser
+      UVMHS.Lib.Parser.Examples
+      UVMHS.Lib.Parser.Loc
+      UVMHS.Lib.Parser.Mixfix
+      UVMHS.Lib.Parser.ParserContext
+      UVMHS.Lib.Parser.ParserError
+      UVMHS.Lib.Parser.ParserInput
+      UVMHS.Lib.Parser.Regex
+      UVMHS.Lib.Pipeline
+      UVMHS.Lib.Pretty
+      UVMHS.Lib.Pretty.Annotation
+      UVMHS.Lib.Pretty.Color
+      UVMHS.Lib.Pretty.Common
+      UVMHS.Lib.Pretty.DerivedInstances
+      UVMHS.Lib.Pretty.Deriving
+      UVMHS.Lib.Pretty.Doc
+      UVMHS.Lib.Pretty.DocA
+      UVMHS.Lib.Pretty.Levels
+      UVMHS.Lib.Pretty.RenderANSI
+      UVMHS.Lib.Pretty.RenderUndertags
+      UVMHS.Lib.Pretty.Shape
+      UVMHS.Lib.Rand
+      UVMHS.Lib.Sep
+      UVMHS.Lib.Shrinky
+      UVMHS.Lib.Substitution
+      UVMHS.Lib.Substitution.Name
+      UVMHS.Lib.Substitution.Subst
+      UVMHS.Lib.Substitution.SubstElem
+      UVMHS.Lib.Substitution.SubstScoped
+      UVMHS.Lib.Substitution.SubstSpaced
+      UVMHS.Lib.Substitution.Substy
+      UVMHS.Lib.Substitution.UVar
+      UVMHS.Lib.Substitution.Var
+      UVMHS.Lib.Testing
+      UVMHS.Lib.THLiftInstances
+      UVMHS.Lib.TreeAnnote
+      UVMHS.Lib.TreeNested
+      UVMHS.Lib.Window
+      UVMHS.Lib.ZerInf
+      UVMHS.Tests.Core
+      UVMHS.Tests.Substitution
+      UVMHSMain
+  other-modules:
+      Paths_uvmhs
+  autogen-modules:
+      Paths_uvmhs
+  hs-source-dirs:
+      src
+  default-extensions:
+      ConstraintKinds
+      CPP
+      DefaultSignatures
+      DataKinds
+      DeriveGeneric
+      DeriveLift
+      EmptyCase
+      ExplicitNamespaces
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      ImpredicativeTypes
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MonadComprehensions
+      MultiParamTypeClasses
+      MultiWayIf
+      NoImplicitPrelude
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternSynonyms
+      PolyKinds
+      QuantifiedConstraints
+      QuasiQuotes
+      RankNTypes
+      RebindableSyntax
+      ScopedTypeVariables
+      StandaloneDeriving
+      StarIsType
+      Strict
+      StrictData
+      TemplateHaskell
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      UndecidableSuperClasses
+      UnicodeSyntax
+      ViewPatterns
+  ghc-options: -optP-Wno-nonportable-include-path -Wall -Wno-orphans -Wno-star-is-type -j2 -fno-prof-auto -O2 -optc-O3 -fspecialise-aggressively -fexpose-all-unfoldings -fprint-potential-instances
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , cassava
+    , containers
+    , directory
+    , filepath
+    , ghc-prim
+    , process
+    , random
+    , template-haskell
+    , text
+    , th-lift-instances
+    , time
+    , vector
+  default-language: Haskell2010
+  if (flag(no-uvmhs-tests))
+    cpp-options: -DNO_UVMHS_TESTS
+
+executable uvmhs
+  main-is: Main.hs
+  other-modules:
+      Paths_uvmhs
+  autogen-modules:
+      Paths_uvmhs
+  hs-source-dirs:
+      src_run
+  default-extensions:
+      ConstraintKinds
+      CPP
+      DefaultSignatures
+      DataKinds
+      DeriveGeneric
+      DeriveLift
+      EmptyCase
+      ExplicitNamespaces
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      ImpredicativeTypes
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MonadComprehensions
+      MultiParamTypeClasses
+      MultiWayIf
+      NoImplicitPrelude
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternSynonyms
+      PolyKinds
+      QuantifiedConstraints
+      QuasiQuotes
+      RankNTypes
+      RebindableSyntax
+      ScopedTypeVariables
+      StandaloneDeriving
+      StarIsType
+      Strict
+      StrictData
+      TemplateHaskell
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      UndecidableSuperClasses
+      UnicodeSyntax
+      ViewPatterns
+  ghc-options: -optP-Wno-nonportable-include-path -Wall -Wno-orphans -Wno-star-is-type -j2 -fno-prof-auto -O2 -optc-O3 -fspecialise-aggressively -fexpose-all-unfoldings -fprint-potential-instances
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , cassava
+    , containers
+    , directory
+    , filepath
+    , ghc-prim
+    , process
+    , random
+    , template-haskell
+    , text
+    , th-lift-instances
+    , time
+    , uvmhs
+    , vector
+  default-language: Haskell2010
+
+test-suite all
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_uvmhs
+  autogen-modules:
+      Paths_uvmhs
+  hs-source-dirs:
+      src_test
+  default-extensions:
+      ConstraintKinds
+      CPP
+      DefaultSignatures
+      DataKinds
+      DeriveGeneric
+      DeriveLift
+      EmptyCase
+      ExplicitNamespaces
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      ImpredicativeTypes
+      InstanceSigs
+      KindSignatures
+      LambdaCase
+      MonadComprehensions
+      MultiParamTypeClasses
+      MultiWayIf
+      NoImplicitPrelude
+      OverloadedStrings
+      PartialTypeSignatures
+      PatternSynonyms
+      PolyKinds
+      QuantifiedConstraints
+      QuasiQuotes
+      RankNTypes
+      RebindableSyntax
+      ScopedTypeVariables
+      StandaloneDeriving
+      StarIsType
+      Strict
+      StrictData
+      TemplateHaskell
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      UndecidableSuperClasses
+      UnicodeSyntax
+      ViewPatterns
+  ghc-options: -optP-Wno-nonportable-include-path -Wall -Wno-orphans -Wno-star-is-type -j2 -fno-prof-auto -O2 -optc-O3 -fspecialise-aggressively -fexpose-all-unfoldings -fprint-potential-instances
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , cassava
+    , containers
+    , directory
+    , filepath
+    , ghc-prim
+    , process
+    , random
+    , template-haskell
+    , text
+    , th-lift-instances
+    , time
+    , uvmhs
+    , vector
+  default-language: Haskell2010

--- a/uvmhs.cabal
+++ b/uvmhs.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           uvmhs
-version:        0.0.1.0
+version:        0.0.2.0
 build-type:     Simple
 
 flag no-uvmhs-tests


### PR DESCRIPTION
I updated the library to be compatible with GHC 9.10.3 (now using snapshot [lts-24.43](https://www.stackage.org/lts-24.43)).

The only migration issue was in `UVMHS.Lib.Testing`, where `TH.CodeQ` no longer automatically gets an instance of `Typeable` inferred for it, since GHC 9.10 is unable to solve `Typeable` instances for polykinded types with representation-polymorphic kinds.

Since this issue only arose for solving `Typeable (TH.CodeQ (𝑇D Test))`, I resolved this by defining a newtype wrapper around it, which prevents typeclass resolution from decomposing `TH.CodeQ (𝑇D Test)` and discovering `TH.CodeQ` is a problem case.

```hs
newtype TypedTest = TypedTest { unTypedTest ∷ TH.CodeQ (𝑇D Test) }
```

There were no other migration issues. All tests pass.
